### PR TITLE
Increase timeout as starting the server in vagrant seems sloooooooooo…

### DIFF
--- a/src/.mocha.js
+++ b/src/.mocha.js
@@ -7,7 +7,3 @@ chai.use(sinonChai);
 global.expect = expect;
 global.sinon = sinon;
 
-beforeEach(function(done) {
-    this.timeout(30000); // A very long environment setup.
-    // setTimeout(done, 2500);
-  });

--- a/src/workItemServce.test.js
+++ b/src/workItemServce.test.js
@@ -40,7 +40,8 @@ describe.only('test pact', (done) => {
     wrapper.removeAllServers();
   });
 
-  beforeEach(done => {
+  beforeEach(function(done) {
+    this.timeout(10000);
    mockServer.start().then(() => {
       console.log('STARTED');
       provider = Pact({consumer: `Consumer ${counter}`,


### PR DESCRIPTION
@scrumtech I made the timeout much longer and it started to pass for me. It seems way slower to start the mock server on vagrant / ubuntu.
